### PR TITLE
Optionally remove any existing mergerfs mounts that are not specified in mergerfs_mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ mergerfs_mounts:
     options: allow_other,use_ino
 ```
 
-### `mergerfs_remove_other_mergerfs_mounts`
+### `mergerfs_remove_undefined_mounts`
 
 Default: `false`
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ mergerfs_mounts:
     options: allow_other,use_ino
 ```
 
+### `mergerfs_unmount_unlisted`
+
+Default: `false`
+
+Remove any existing mergerfs mounts that are not listed in `mergerfs_mounts`
+
 ### `mergerfs_github_releases_url`
 
 Default: [`https://github.com/trapexit/mergerfs/releases`](https://github.com/trapexit/mergerfs/releases)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ mergerfs_mounts:
     options: allow_other,use_ino
 ```
 
-### `mergerfs_unmount_unlisted`
+### `mergerfs_remove_other_mergerfs_mounts`
 
 Default: `false`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,4 +26,4 @@ mergerfs_github_releases_url: https://github.com/trapexit/mergerfs/releases
 mergerfs_install_prerequisites: true
 
 # Whether mergerfs mounts not listed in `mergerfs_mounts` should be unmounted
-mergerfs_unmount_unlisted: false
+mergerfs_remove_other_mergerfs_mounts: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,4 +26,4 @@ mergerfs_github_releases_url: https://github.com/trapexit/mergerfs/releases
 mergerfs_install_prerequisites: true
 
 # Whether mergerfs mounts not listed in `mergerfs_mounts` should be unmounted
-mergerfs_remove_other_mergerfs_mounts: false
+mergerfs_remove_undefined_mounts: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,6 @@ mergerfs_github_releases_url: https://github.com/trapexit/mergerfs/releases
 
 # Whether the role should install prerequisites for you.
 mergerfs_install_prerequisites: true
+
+# Whether mergerfs mounts not listed in `mergerfs_mounts` should be unmounted
+mergerfs_unmount_unlisted: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,4 +42,4 @@
         state: absent
       loop: "{{ existing_mergerfs_mounts.stdout_lines }}"
       when: item not in mergerfs_mounts | map(attribute='path') | list
-  when: mergerfs_remove_other_mergerfs_mounts
+  when: mergerfs_remove_undefined_mounts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,3 +28,18 @@
   loop: "{{ mergerfs_mounts }}"
   become: true
   tags: [mergerfs, mergerfs_install]
+
+- name: Unmount unlisted mergerfs filesystems
+  block:
+    - name: List existing mergerfs filesystems
+      # ansible_mounts doesn't list fuse mounts
+      ansible.builtin.command: "findmnt -t fuse.mergerfs -o TARGET -n"
+      changed_when: false
+      register: existing_mergerfs_mounts
+    - name: Unmount mergerfs filesystems
+      ansible.posix.mount:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ existing_mergerfs_mounts.stdout_lines }}"
+      when: item not in mergerfs_mounts | map(attribute='path') | list
+  when: mergerfs_unmount_unlisted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,4 +42,4 @@
         state: absent
       loop: "{{ existing_mergerfs_mounts.stdout_lines }}"
       when: item not in mergerfs_mounts | map(attribute='path') | list
-  when: mergerfs_unmount_unlisted
+  when: mergerfs_remove_other_mergerfs_mounts


### PR DESCRIPTION
Removes any pre-existing mergerfs mounts that are not specified in `mergerfs_mounts` when `mergerfs_remove_other_mergerfs_mounts: true`

Whilst mounts can be removed by setting `state: absent`, doing requires that the mount remain in the list, and will also unmount the mount even if it's not a mergerfs mount - preventing the reuse of the mountpoint elsewhere.