### PR TITLE
fix: Get latest release only if requested.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
         url: "{{ mergerfs_github_repo_url }}/releases/latest"
       register: mergerfs_github_release_page
       check_mode: false
+      when: mergerfs_version == "latest"
 
     - name: Set latest mergerfs version fact
       ansible.builtin.set_fact:


### PR DESCRIPTION
Small tweak to only get the latest release if version is set to `latest`.