### PR TITLE
fix: role hangs at "Get latest release information from GitHub"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,8 +15,6 @@
 # to the release page, where we can find the version number in the URL.
 
 - name: Get/parse release info
-  delegate_to: localhost
-  run_once: true
   block:
     - name: Get latest release information from GitHub
       ansible.builtin.uri:


### PR DESCRIPTION
Fixes #26.

The delegation to localhost was seen to cause the role to hang at the "Get latest release information from GitHub" step for reasons unknown.

Since we aren't directly querying the API anyway, this wasn't of great value. If we had been, it would've been a nice way of reducing the number of API hits when targeting multiple hosts with the role, but I digress.